### PR TITLE
Fix for #92 Display warning about uninstalled plugins in the Administration section of SonarQube

### DIFF
--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/DevonfwJavaProfile.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/DevonfwJavaProfile.java
@@ -1,14 +1,9 @@
 package com.devonfw.ide.sonarqube.common.impl;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -26,38 +21,9 @@ import org.xml.sax.SAXException;
  */
 @SonarLintSide
 public class DevonfwJavaProfile implements BuiltInQualityProfilesDefinition {
-
   private static final String DEVON4J_XML = "/com/devonfw/ide/sonarqube/common/rules/devon4j/devon4j.xml";
 
   private static final Logger logger = Logger.getGlobal();
-
-  private static final String QUALINSIGHT = "qualinsight-plugins-sonarqube-smell-plugin";
-
-  private static final String PMD = "sonar-pmd-plugin";
-
-  private static final String CHECKSTYLE = "checkstyle-sonar-plugin";
-
-  private static final String FINDBUGS = "sonar-findbugs-plugin";
-
-  private static List<String> FORBIDDEN_REPO_KEYS = new ArrayList<>();
-
-  private File pluginDirectory;
-
-  private List<String> pluginList;
-
-  // Use this constructor only for testing purposes
-  DevonfwJavaProfile(File pluginDirectory) {
-
-    this.pluginDirectory = pluginDirectory;
-  }
-
-  /**
-   * The constructor
-   */
-  public DevonfwJavaProfile() {
-
-    this(new File("extensions/plugins"));
-  }
 
   @Override
   public void define(Context context) {
@@ -70,17 +36,12 @@ public class DevonfwJavaProfile implements BuiltInQualityProfilesDefinition {
     }
     NodeList ruleList = parsedXml.getElementsByTagName("rule");
     NodeList childrenOfRule;
-    disableRepoKeys();
-
     NewBuiltInActiveRule currentRule;
     String repoKey = null;
     String ruleKey = null;
     String severity = "";
-
     for (int i = 0; i < ruleList.getLength(); i++) {
-
       childrenOfRule = ruleList.item(i).getChildNodes();
-
       for (int j = 0; j < childrenOfRule.getLength(); j++) {
         switch (childrenOfRule.item(j).getNodeName()) {
           case "repositoryKey":
@@ -96,15 +57,13 @@ public class DevonfwJavaProfile implements BuiltInQualityProfilesDefinition {
             break;
         }
       }
-
-      if (!(FORBIDDEN_REPO_KEYS.contains(repoKey) || repoKey == null || ruleKey == null)) {
+      if (!(SonarDevon4jPlugin.FORBIDDEN_REPO_KEYS.contains(repoKey) || repoKey == null || ruleKey == null)) {
         currentRule = devonfwJava.activateRule(repoKey, ruleKey);
         if (severity.isEmpty()) {
           currentRule.overrideSeverity(severity);
         }
       }
     }
-
     devonfwJava.done();
   }
 
@@ -123,49 +82,6 @@ public class DevonfwJavaProfile implements BuiltInQualityProfilesDefinition {
     } catch (SAXException sax) {
       logger.log(Level.WARNING, "There was a problem parsing the file.");
       return null;
-    }
-  }
-
-  private List<String> getPlugins() {
-
-    if (this.pluginList == null) {
-      File[] fileList = this.pluginDirectory.listFiles(f -> f.getName().endsWith(".jar") && f.isFile());
-      this.pluginList = Arrays.asList(fileList).stream().map(f -> f.getName()).collect(Collectors.toList());
-    }
-
-    return this.pluginList;
-  }
-
-  private boolean hasPlugin(String name) {
-
-    for (String plugin : getPlugins()) {
-      if (plugin.contains(name)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  private void disableRepoKeys() {
-
-    if (!hasPlugin(QUALINSIGHT)) {
-      FORBIDDEN_REPO_KEYS.add("qualinsight-smells");
-    }
-
-    if (!hasPlugin(PMD)) {
-      FORBIDDEN_REPO_KEYS.add("pmd");
-      FORBIDDEN_REPO_KEYS.add("pmd-unit-tests");
-    }
-
-    if (!hasPlugin(CHECKSTYLE)) {
-      FORBIDDEN_REPO_KEYS.add("checkstyle");
-    }
-
-    if (!hasPlugin(FINDBUGS)) {
-      FORBIDDEN_REPO_KEYS.add("findbugs");
-      FORBIDDEN_REPO_KEYS.add("findsecbugs");
-      FORBIDDEN_REPO_KEYS.add("fb-contrib");
     }
   }
 }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPlugin.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPlugin.java
@@ -1,4 +1,5 @@
 package com.devonfw.ide.sonarqube.common.impl;
+
 import org.sonar.api.Plugin;
 import org.sonar.api.PropertyType;
 import org.sonar.api.config.PropertyDefinition;
@@ -7,35 +8,50 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
 /**
  * The {@link Plugin} to integrate devonfw architecture rules into SonarQube.
  */
 public class SonarDevon4jPlugin implements Plugin {
   static final String CONFIG_KEY = "sonar.devon.config";
+
   static final String FORBIDDEN_CONF_KEY = "sonar.devon.forbiddenConf";
+
   static final String DISABLED = "Disabled";
+
   static final String ISSUES_SEVERITY_KEY = "sonar.Devon.preview.issuesSeverity";
+
   private static final String QUALINSIGHT = "qualinsight-plugins-sonarqube-smell-plugin";
+
   private static final String PMD = "sonar-pmd-plugin";
+
   private static final String CHECKSTYLE = "checkstyle-sonar-plugin";
+
   private static final String FINDBUGS = "sonar-findbugs-plugin";
+
   static List<String> FORBIDDEN_REPO_KEYS = new ArrayList<>();
+
   private File pluginDirectory;
+
   private List<String> pluginList;
-  private List<String> requiredPlugins = Arrays.asList("qualinsight-plugins-sonarqube-smell-plugin",
-      "sonar-pmd-plugin", "checkstyle-sonar-plugin", "sonar-findbugs-plugin");
+
   // Use this constructor only for testing purposes
   SonarDevon4jPlugin(File pluginDirectory) {
+
     this.pluginDirectory = pluginDirectory;
   }
+
   /**
    * The constructor
    */
   public SonarDevon4jPlugin() {
+
     this(new File("extensions/plugins"));
   }
+
   @Override
   public void define(Context context) {
+
     context.addExtensions(DevonSonarDefinition.class, DevonSonarRegistrar.class, DevonfwJavaProfile.class);
     context.addExtension(PropertyDefinition.builder(CONFIG_KEY).name("Config JSON")
         .description("Configuration of business architecture").category("devonfw").subCategory("")
@@ -44,19 +60,21 @@ public class SonarDevon4jPlugin implements Plugin {
         .build());
     context.addExtension(PropertyDefinition.builder(DISABLED).name("Warning")
         .description("Missing plugins for full initialization of devonfw quality profile").category("devonfw")
-        .subCategory("").type(PropertyType.TEXT).defaultValue(getMissingPlugins())
-        .build());
-    disableRepoKeys();
+        .subCategory("").type(PropertyType.TEXT).defaultValue(getMissingPlugins()).build());
     disableRepoKeys();
   }
+
   private List<String> getPlugins() {
+
     if (this.pluginList == null) {
       File[] fileList = this.pluginDirectory.listFiles(f -> f.getName().endsWith(".jar") && f.isFile());
       this.pluginList = Arrays.asList(fileList).stream().map(f -> f.getName()).collect(Collectors.toList());
     }
     return this.pluginList;
   }
+
   private boolean hasPlugin(String name) {
+
     for (String plugin : getPlugins()) {
       if (plugin.contains(name)) {
         return true;
@@ -64,7 +82,9 @@ public class SonarDevon4jPlugin implements Plugin {
     }
     return false;
   }
+
   private void disableRepoKeys() {
+
     if (!hasPlugin(QUALINSIGHT)) {
       FORBIDDEN_REPO_KEYS.add("qualinsight-smells");
     }
@@ -81,14 +101,21 @@ public class SonarDevon4jPlugin implements Plugin {
       FORBIDDEN_REPO_KEYS.add("fb-contrib");
     }
   }
+
   private String getMissingPlugins() {
+
     StringBuilder missingPlugins = new StringBuilder();
-    missingPlugins.append("Please install plugins listed below: \n\n");
+    List<String> requiredPlugins = Arrays.asList(QUALINSIGHT, CHECKSTYLE, PMD, FINDBUGS);
     requiredPlugins.forEach(requiredPlugin -> {
       if (!hasPlugin(requiredPlugin)) {
         missingPlugins.append("- " + requiredPlugin + "\n");
       }
     });
+    if (missingPlugins.length() != 0) {
+      missingPlugins.insert(0, "Please install plugins listed below: \n\n");
+    } else {
+      missingPlugins.append("All plugins installed properly");
+    }
     return missingPlugins.toString();
   }
 }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPlugin.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPlugin.java
@@ -1,30 +1,94 @@
 package com.devonfw.ide.sonarqube.common.impl;
-
 import org.sonar.api.Plugin;
 import org.sonar.api.PropertyType;
 import org.sonar.api.config.PropertyDefinition;
-
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 /**
  * The {@link Plugin} to integrate devonfw architecture rules into SonarQube.
  */
 public class SonarDevon4jPlugin implements Plugin {
-
   static final String CONFIG_KEY = "sonar.devon.config";
-
   static final String FORBIDDEN_CONF_KEY = "sonar.devon.forbiddenConf";
-
   static final String DISABLED = "Disabled";
-
   static final String ISSUES_SEVERITY_KEY = "sonar.Devon.preview.issuesSeverity";
-
+  private static final String QUALINSIGHT = "qualinsight-plugins-sonarqube-smell-plugin";
+  private static final String PMD = "sonar-pmd-plugin";
+  private static final String CHECKSTYLE = "checkstyle-sonar-plugin";
+  private static final String FINDBUGS = "sonar-findbugs-plugin";
+  static List<String> FORBIDDEN_REPO_KEYS = new ArrayList<>();
+  private File pluginDirectory;
+  private List<String> pluginList;
+  private List<String> requiredPlugins = Arrays.asList("qualinsight-plugins-sonarqube-smell-plugin",
+      "sonar-pmd-plugin", "checkstyle-sonar-plugin", "sonar-findbugs-plugin");
+  // Use this constructor only for testing purposes
+  SonarDevon4jPlugin(File pluginDirectory) {
+    this.pluginDirectory = pluginDirectory;
+  }
+  /**
+   * The constructor
+   */
+  public SonarDevon4jPlugin() {
+    this(new File("extensions/plugins"));
+  }
   @Override
   public void define(Context context) {
-
     context.addExtensions(DevonSonarDefinition.class, DevonSonarRegistrar.class, DevonfwJavaProfile.class);
     context.addExtension(PropertyDefinition.builder(CONFIG_KEY).name("Config JSON")
         .description("Configuration of business architecture").category("devonfw").subCategory("")
         .type(PropertyType.TEXT)
         .defaultValue("{\"architecture\":{\"components\":[\n{\"name\":\"component1\",\\\"dependencies\\\":[]}}\n]}}")
         .build());
+    context.addExtension(PropertyDefinition.builder(DISABLED).name("Warning")
+        .description("Missing plugins for full initialization of devonfw quality profile").category("devonfw")
+        .subCategory("").type(PropertyType.TEXT).defaultValue(getMissingPlugins())
+        .build());
+    disableRepoKeys();
+    disableRepoKeys();
+  }
+  private List<String> getPlugins() {
+    if (this.pluginList == null) {
+      File[] fileList = this.pluginDirectory.listFiles(f -> f.getName().endsWith(".jar") && f.isFile());
+      this.pluginList = Arrays.asList(fileList).stream().map(f -> f.getName()).collect(Collectors.toList());
+    }
+    return this.pluginList;
+  }
+  private boolean hasPlugin(String name) {
+    for (String plugin : getPlugins()) {
+      if (plugin.contains(name)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  private void disableRepoKeys() {
+    if (!hasPlugin(QUALINSIGHT)) {
+      FORBIDDEN_REPO_KEYS.add("qualinsight-smells");
+    }
+    if (!hasPlugin(PMD)) {
+      FORBIDDEN_REPO_KEYS.add("pmd");
+      FORBIDDEN_REPO_KEYS.add("pmd-unit-tests");
+    }
+    if (!hasPlugin(CHECKSTYLE)) {
+      FORBIDDEN_REPO_KEYS.add("checkstyle");
+    }
+    if (!hasPlugin(FINDBUGS)) {
+      FORBIDDEN_REPO_KEYS.add("findbugs");
+      FORBIDDEN_REPO_KEYS.add("findsecbugs");
+      FORBIDDEN_REPO_KEYS.add("fb-contrib");
+    }
+  }
+  private String getMissingPlugins() {
+    StringBuilder missingPlugins = new StringBuilder();
+    missingPlugins.append("Please install plugins listed below: \n\n");
+    requiredPlugins.forEach(requiredPlugin -> {
+      if (!hasPlugin(requiredPlugin)) {
+        missingPlugins.append("- " + requiredPlugin + "\n");
+      }
+    });
+    return missingPlugins.toString();
   }
 }

--- a/src/main/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPlugin.java
+++ b/src/main/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPlugin.java
@@ -114,7 +114,7 @@ public class SonarDevon4jPlugin implements Plugin {
     if (missingPlugins.length() != 0) {
       missingPlugins.insert(0, "Please install plugins listed below: \n\n");
     } else {
-      missingPlugins.append("All plugins installed properly");
+      missingPlugins.append("All plugins installed properly.");
     }
     return missingPlugins.toString();
   }

--- a/src/test/java/com/devonfw/ide/sonarqube/common/impl/DevonfwJavaProfileTest.java
+++ b/src/test/java/com/devonfw/ide/sonarqube/common/impl/DevonfwJavaProfileTest.java
@@ -1,7 +1,5 @@
 package com.devonfw.ide.sonarqube.common.impl;
 
-import java.io.File;
-
 import org.junit.Test;
 import org.sonar.api.server.profile.BuiltInQualityProfilesDefinition;
 import org.sonar.plugins.java.Java;
@@ -13,7 +11,6 @@ import com.devonfw.module.test.common.base.ModuleTest;
  *
  */
 public class DevonfwJavaProfileTest extends ModuleTest {
-
   /**
    * Test of {@link DevonfwJavaProfile}
    */
@@ -21,13 +18,10 @@ public class DevonfwJavaProfileTest extends ModuleTest {
   public void test() {
 
     // Create new test profile
-    File pluginDir = new File("src/test/files/qualityprofile/extensions/plugins");
-    DevonfwJavaProfile profileDef = new DevonfwJavaProfile(pluginDir);
-
+    DevonfwJavaProfile profileDef = new DevonfwJavaProfile();
     BuiltInQualityProfilesDefinition.Context context = new BuiltInQualityProfilesDefinition.Context();
     profileDef.define(context);
     BuiltInQualityProfilesDefinition.BuiltInQualityProfile profile = context.profile(Java.KEY, "devonfw Java");
-
     // Assertions
     assertThat(profile.rules()).isNotEmpty();
     assertThat(profile.language()).isEqualTo(Java.KEY);

--- a/src/test/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPluginTest.java
+++ b/src/test/java/com/devonfw/ide/sonarqube/common/impl/SonarDevon4jPluginTest.java
@@ -1,5 +1,6 @@
 package com.devonfw.ide.sonarqube.common.impl;
 
+import java.io.File;
 import java.util.List;
 
 import org.junit.Test;
@@ -16,22 +17,20 @@ import com.devonfw.module.test.common.base.ModuleTest;
  * Test of {@link SonarDevon4jPlugin}
  */
 public class SonarDevon4jPluginTest extends ModuleTest {
-
   /**
    * Test of {@link SonarDevon4jPlugin}
    */
   @Test
   public void test() {
 
-    SonarDevon4jPlugin plugin = new SonarDevon4jPlugin();
+    File pluginDir = new File("src/test/files/qualityprofile/extensions/plugins");
+    SonarDevon4jPlugin plugin = new SonarDevon4jPlugin(pluginDir);
     PluginContextImpl.Builder builder = new PluginContextImpl.Builder();
     builder.setSonarRuntime(
         SonarRuntimeImpl.forSonarQube(Version.create(5, 7), SonarQubeSide.SERVER, SonarEdition.SONARCLOUD));
     Plugin.Context context = builder.build();
     plugin.define(context);
     List<Class<?>> extensions = context.getExtensions();
-
     assertThat(extensions).contains(DevonSonarDefinition.class, DevonSonarRegistrar.class);
   }
-
 }


### PR DESCRIPTION
#92 
-creating a new field with warning about uninstalled plugins
-new method checking  plugins (getMissingPlugins)